### PR TITLE
Update cw-plus packages to 0.15.0 and cosmwasm_std to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,17 +64,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
+checksum = "10cb32eb596428347033db2da3028558ef8ec506ae00605932eef4b24972baa2"
 dependencies = [
- "digest",
+ "digest 0.10.5",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.3",
@@ -74,32 +83,47 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b36e527620a2a3e00e46b6e731ab6c9b68d11069c986f7d7be8eba79ef081a4"
+checksum = "0faf3a02389f78d6173b7e680751205015d5406f8abbaa9aa36fd216adc9f10d"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772e80bbad231a47a2068812b723a1ff81dd4a0d56c9391ac748177bea3a61da"
+checksum = "d5d13e9ee950418b0ac90a2579b8769640e0b07e6d06d9d5f5b512ba64265e5a"
 dependencies = [
+ "cosmwasm-schema-derive",
  "schemars",
+ "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d5e04d338db6af813d0633fe9ab6a5cd36ae83796ca769ae13d6910a5861df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875994993c2082a6fcd406937bf0fca21c349e4a624f3810253a14fa83a3a195"
+checksum = "b3409b349f282924c8099b554aae6fe70e4eb97d6a64697ae13c8be25a7eb158"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
  "schemars",
  "serde",
@@ -110,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18403b07304d15d304dad11040d45bbcaf78d603b4be3fb5e2685c16f9229b5"
+checksum = "f024880dd46c053f30dd31f3b3aab8197b5cfaafe86c9e302c845df0cff44a0a"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -135,9 +159,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -146,13 +170,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
@@ -162,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -170,13 +194,14 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0bc6019b4d3d81e11f5c384bcce7173e2210bd654d75c6c9668e12cca05dfa"
+checksum = "0cc1bc794002a1e409e4a0c8aac8839f065fb387087d51b9efa94890b82c38e7"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "schemars",
  "serde",
  "thiserror",
@@ -191,11 +216,11 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (git+https://github.com/CosmWasm/cw-plus?branch=main)",
+ "cw-multi-test 0.13.4",
  "cw-paginate",
  "cw-proposal-sudo",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-balance-voting",
@@ -234,14 +259,13 @@ dependencies = [
 [[package]]
 name = "cw-multi-test"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f9a8ab7c3c29ec93cb7a39ce4b14a05e053153b4a17ef7cf2246af1b7c087e"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#07d1f718a40bb33574f4ac40141aa6a948bc8c24"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
  "derivative",
  "itertools",
  "prost",
@@ -252,14 +276,15 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.4"
-source = "git+https://github.com/CosmWasm/cw-plus?branch=main#07d1f718a40bb33574f4ac40141aa6a948bc8c24"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.13.4 (git+https://github.com/CosmWasm/cw-plus?branch=main)",
- "cw-utils 0.13.4 (git+https://github.com/CosmWasm/cw-plus?branch=main)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "derivative",
  "itertools",
  "prost",
@@ -275,8 +300,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
  "cw2",
  "schemars",
  "serde",
@@ -291,8 +316,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -307,8 +332,8 @@ version = "1.1.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
  "serde",
 ]
 
@@ -322,9 +347,9 @@ dependencies = [
  "cw-core",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-balance-voting",
@@ -354,8 +379,8 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
  "cw2",
  "schemars",
  "serde",
@@ -365,8 +390,7 @@ dependencies = [
 [[package]]
 name = "cw-storage-plus"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#07d1f718a40bb33574f4ac40141aa6a948bc8c24"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -375,8 +399,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.13.4"
-source = "git+https://github.com/CosmWasm/cw-plus?branch=main#07d1f718a40bb33574f4ac40141aa6a948bc8c24"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ba3fb5fad2dce94263d070848b2befc46b5c8e4929adfb9a3595267823d6ec"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -386,8 +411,7 @@ dependencies = [
 [[package]]
 name = "cw-utils"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#07d1f718a40bb33574f4ac40141aa6a948bc8c24"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -397,35 +421,41 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.4"
-source = "git+https://github.com/CosmWasm/cw-plus?branch=main#07d1f718a40bb33574f4ac40141aa6a948bc8c24"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a67007ff056f4cd034f361c8ed69780c0180959b9c8037c84f3caa78120faf5"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
+ "cw2",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "cw2"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
+checksum = "b0a1924a28607bf7cb9fd6681a64feea3e5fa9a8cb71fb4d24cf33635b21065a"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb782b8f110819a4eb5dbbcfed25ffba49ec16bbe32b4ad8da50a5ce68fec05"
+checksum = "56a48e4a85c0a31484e053a3eea15abfc3ed24fafc1a1a3e91181a0bd3a8ee91"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.15.0",
  "schemars",
  "serde",
 ]
@@ -439,9 +469,9 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -452,16 +482,18 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0306e606581f4fb45e82bcbb7f0333179ed53dd949c6523f01a99b4bfc1475a0"
+checksum = "09260094811a95a8980f3c775e79e019a5695fa2ce291d87c0e79ffa00609556"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
@@ -475,9 +507,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -495,9 +527,9 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -509,38 +541,41 @@ dependencies = [
 
 [[package]]
 name = "cw3"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe19462a7f644ba60c19d3443cb90d00c50d9b6b3b0a3a7fca93df8261af979b"
+checksum = "961f6959e04de1bc61f4fc3f333bc039998e2aedeab4aa79ba48239cf2d3edfa"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.15.0",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw4"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acc3549d5ce11c6901b3a676f2e2628684722197054d97cd0101ea174ed5cbd"
+checksum = "ce632c71b9e41aed1f9676ab864d77eb32b270a207ec60cf13d557346b32b751"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw4-group"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c95c89153e7831c8306c8eba40a3daa76f9c7b8f5179dd0b8628aca168ec7a"
+checksum = "413bedf93bc66d0a3748270782e537bdafaebe23dbb54e45e7e2c1bf06b9479a"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw4",
  "schemars",
@@ -557,9 +592,9 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw4",
  "cw4-group",
@@ -570,25 +605,27 @@ dependencies = [
 
 [[package]]
 name = "cw721"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b9fd71276795554c35899bb3a378561ed0c288d231113e9915f6ee1f42b7b5"
+checksum = "20dfe04f86e5327956b559ffcc86d9a43167391f37402afd8bf40b0be16bee4d"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.15.0",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw721-base"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61200af4e027af2d7485dbdc37c2a9c4093b6b2f2b811732329ef456076f97e"
+checksum = "62c3ee3b669fc2a8094301a73fd7be97a7454d4df2650c33599f737e8f254d24"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw721",
  "schemars",
@@ -598,11 +635,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -626,6 +664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,9 +682,9 @@ checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "85789ce7dfbd0f0624c07ef653a08bb2ebf43d3e16531361f46d36dd54334fed"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -653,7 +702,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "zeroize",
 ]
@@ -666,16 +715,18 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
+ "digest 0.10.5",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -684,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -732,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -749,12 +800,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -762,7 +812,7 @@ name = "indexable-hooks"
 version = "1.1.0"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
  "schemars",
  "serde",
  "thiserror",
@@ -785,15 +835,14 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "3636d281d46c3b64182eb3a0a42b7b483191a2ecc3f05301fa67403f7c9bc949"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -810,13 +859,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -852,10 +900,10 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-core",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
  "cw-proposal-single",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-balance-voting",
@@ -942,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -983,10 +1031,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",
@@ -995,10 +1044,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.137"
+name = "semver"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "serde"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -1014,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1051,28 +1106,39 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signature"
-version = "1.4.0"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a622c5fc69cf2a070d3217981bded5071cdd1b1ac17ae906646debae83579b54"
+dependencies = [
+ "digest 0.10.5",
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
@@ -1087,9 +1153,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -1106,9 +1172,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
+ "cw-storage-plus 0.15.0",
+ "cw-utils 0.15.0",
  "cw2",
  "cw20",
  "cw20-base",
@@ -1146,7 +1212,7 @@ name = "testing"
 version = "1.1.0"
 dependencies = [
  "cosmwasm-std",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.15.0",
  "rand",
  "voting",
 ]

--- a/contracts/cw-core/Cargo.toml
+++ b/contracts/cw-core/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = { version = "1.1.0", features = ["ibc3"] }
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 cw-utils = "0.15.0"
@@ -44,7 +44,7 @@ cw-core-macros = { version = "1.1.0", path = "../../packages/cw-core-macros" }
 cw-paginate = { version = "1.1.0", path = "../../packages/cw-paginate" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 # TODO: We are using the main branch of cw-multi-test until the next release, because we need recent stargate parsing fixes
 cw-multi-test = { git = "https://github.com/CosmWasm/cw-plus", branch = "main", features = [
   "stargate",

--- a/contracts/cw-core/Cargo.toml
+++ b/contracts/cw-core/Cargo.toml
@@ -31,11 +31,11 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
-cw-utils = "0.13"
-cw20 = "0.13"
-cw721 = "0.13"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
+cw-utils = "0.15.0"
+cw20 = "0.15.0"
+cw721 = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
@@ -49,7 +49,7 @@ cosmwasm-schema = { version = "1.0.0" }
 cw-multi-test = { git = "https://github.com/CosmWasm/cw-plus", branch = "main", features = [
   "stargate",
 ] }
-cw20-base = "0.13"
-cw721-base = "0.13"
+cw20-base = "0.15.0"
+cw721-base = "0.15.0"
 cw-proposal-sudo = { version = "1.1.0", path = "../../debug/cw-proposal-sudo" }
 cw20-balance-voting = { version = "1.1.0", path = "../../debug/cw20-balance-voting" }

--- a/contracts/cw-core/src/tests.rs
+++ b/contracts/cw-core/src/tests.rs
@@ -1730,11 +1730,11 @@ fn test_cw721_receive() {
     app.execute_contract(
         Addr::unchecked(CREATOR_ADDR),
         cw721_addr.clone(),
-        &cw721_base::msg::ExecuteMsg::Mint(cw721_base::msg::MintMsg::<Option<Empty>> {
+        &cw721_base::msg::ExecuteMsg::<Empty, Empty>::Mint(cw721_base::msg::MintMsg::<Empty> {
             token_id: "ekez".to_string(),
             owner: CREATOR_ADDR.to_string(),
             token_uri: None,
-            extension: None,
+            extension: Empty {},
         }),
         &[],
     )
@@ -1743,7 +1743,7 @@ fn test_cw721_receive() {
     app.execute_contract(
         Addr::unchecked(CREATOR_ADDR),
         cw721_addr.clone(),
-        &cw721_base::msg::ExecuteMsg::<Option<Empty>>::SendNft {
+        &cw721_base::msg::ExecuteMsg::<Option<Empty>, Empty>::SendNft {
             contract: gov_addr.to_string(),
             token_id: "ekez".to_string(),
             msg: to_binary("").unwrap(),
@@ -1813,11 +1813,11 @@ fn test_cw721_receive_no_auto_add() {
     app.execute_contract(
         Addr::unchecked(CREATOR_ADDR),
         cw721_addr.clone(),
-        &cw721_base::msg::ExecuteMsg::Mint(cw721_base::msg::MintMsg::<Option<Empty>> {
+        &cw721_base::msg::ExecuteMsg::Mint::<Empty, Empty>(cw721_base::msg::MintMsg::<Empty> {
             token_id: "ekez".to_string(),
             owner: CREATOR_ADDR.to_string(),
             token_uri: None,
-            extension: None,
+            extension: Empty {},
         }),
         &[],
     )
@@ -1826,7 +1826,7 @@ fn test_cw721_receive_no_auto_add() {
     app.execute_contract(
         Addr::unchecked(CREATOR_ADDR),
         cw721_addr.clone(),
-        &cw721_base::msg::ExecuteMsg::<Option<Empty>>::SendNft {
+        &cw721_base::msg::ExecuteMsg::<Option<Empty>, Empty>::SendNft {
             contract: gov_addr.to_string(),
             token_id: "ekez".to_string(),
             msg: to_binary("").unwrap(),

--- a/contracts/cw-named-groups/Cargo.toml
+++ b/contracts/cw-named-groups/Cargo.toml
@@ -32,8 +32,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 schemars = "0.8"
@@ -41,5 +41,5 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/contracts/cw-named-groups/Cargo.toml
+++ b/contracts/cw-named-groups/Cargo.toml
@@ -34,12 +34,12 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"

--- a/contracts/cw-names-registry/Cargo.toml
+++ b/contracts/cw-names-registry/Cargo.toml
@@ -31,15 +31,15 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
-cw20 = "0.13"
-cw20-base = { version = "0.13", features = ["library"] }
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
+cw20 = "0.15.0"
+cw20-base = { version = "0.15.0", features = ["library"] }
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"
 anyhow = { version = "1.0.51" }

--- a/contracts/cw-names-registry/Cargo.toml
+++ b/contracts/cw-names-registry/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 cw20 = "0.15.0"
@@ -40,6 +40,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
 anyhow = { version = "1.0.51" }

--- a/contracts/cw-proposal-single/Cargo.toml
+++ b/contracts/cw-proposal-single/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = { version = "1.1.0", features = ["ibc3"] }
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw-utils = "0.15.0"
 cw2 = "0.15.0"
@@ -48,7 +48,7 @@ proposal-hooks = { version = "*", path = "../../packages/proposal-hooks" }
 vote-hooks = { version = "*", path = "../../packages/vote-hooks" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
 cw4-voting = { path = "../cw4-voting", version = "*" }
 cw20-balance-voting = { path = "../../debug/cw20-balance-voting", version = "*" }

--- a/contracts/cw-proposal-single/Cargo.toml
+++ b/contracts/cw-proposal-single/Cargo.toml
@@ -31,11 +31,11 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw-utils = "0.13"
-cw2 = "0.13"
-cw20 = "0.13"
-cw3 = "0.13"
+cw-storage-plus = "0.15.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
+cw20 = "0.15.0"
+cw3 = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
@@ -49,12 +49,12 @@ vote-hooks = { version = "*", path = "../../packages/vote-hooks" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"
 cw4-voting = { path = "../cw4-voting", version = "*" }
 cw20-balance-voting = { path = "../../debug/cw20-balance-voting", version = "*" }
 cw20-staked-balance-voting = { path = "../cw20-staked-balance-voting", version = "*" }
 testing = { version = "*", path = "../../packages/testing" }
 cw20-stake = { path = "../cw20-stake", version = "*" }
-cw20-base = "0.13"
-cw4 = "0.13"
-cw4-group = "0.13"
+cw20-base = "0.15.0"
+cw4 = "0.15.0"
+cw4-group = "0.15.0"

--- a/contracts/cw20-stake-external-rewards/Cargo.toml
+++ b/contracts/cw20-stake-external-rewards/Cargo.toml
@@ -16,8 +16,8 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = { version = "0.15.0" }
 cw-controllers = "0.15.0"
 cw20 = { version = "0.15.0" }
@@ -30,6 +30,6 @@ thiserror = { version = "1.0.30" }
 cw20-stake = { path = "../cw20-stake", features = ["library"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = { version = "0.15.0" }
 anyhow = { version = "1.0.51" }

--- a/contracts/cw20-stake-external-rewards/Cargo.toml
+++ b/contracts/cw20-stake-external-rewards/Cargo.toml
@@ -18,12 +18,12 @@ library = []
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = { version = "0.13" }
-cw-controllers = "0.13"
-cw20 = { version = "0.13" }
-cw-utils = { version = "0.13" }
-cw20-base = { version = "0.13", features = ["library"] }
-cw2 = "0.13"
+cw-storage-plus = { version = "0.15.0" }
+cw-controllers = "0.15.0"
+cw20 = { version = "0.15.0" }
+cw-utils = { version = "0.15.0" }
+cw20-base = { version = "0.15.0", features = ["library"] }
+cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
@@ -31,5 +31,5 @@ cw20-stake = { path = "../cw20-stake", features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = { version = "0.13" }
+cw-multi-test = { version = "0.15.0" }
 anyhow = { version = "1.0.51" }

--- a/contracts/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/cw20-stake-reward-distributor/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 cw20 = { version = "0.15.0" }
@@ -42,5 +42,5 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/contracts/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/cw20-stake-reward-distributor/Cargo.toml
@@ -31,16 +31,16 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
-cw20 = { version = "0.13" }
-cw-utils = "0.13"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
+cw20 = { version = "0.15.0" }
+cw-utils = "0.15.0"
 schemars = "0.8"
-cw20-base = { version = "0.13", features = ["library"] }
+cw20-base = { version = "0.15.0", features = ["library"] }
 cw20-stake = { path = "../cw20-stake", features = ["library"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"

--- a/contracts/cw20-stake/Cargo.toml
+++ b/contracts/cw20-stake/Cargo.toml
@@ -16,8 +16,8 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = { version = "0.15.0" }
 cw-controllers = "0.15.0"
 cw20 = { version = "0.15.0" }
@@ -29,6 +29,6 @@ serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = { version = "0.15.0" }
 anyhow = { version = "1.0.51" }

--- a/contracts/cw20-stake/Cargo.toml
+++ b/contracts/cw20-stake/Cargo.toml
@@ -18,17 +18,17 @@ library = []
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = { version = "0.13" }
-cw-controllers = "0.13"
-cw20 = { version = "0.13" }
-cw-utils = { version = "0.13" }
-cw20-base = { version = "0.13", features = ["library"] }
-cw2 = "0.13"
+cw-storage-plus = { version = "0.15.0" }
+cw-controllers = "0.15.0"
+cw20 = { version = "0.15.0" }
+cw-utils = { version = "0.15.0" }
+cw20-base = { version = "0.15.0", features = ["library"] }
+cw2 = "0.15.0"
 schemars = "0.8.8"
 serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = { version = "0.13" }
+cw-multi-test = { version = "0.15.0" }
 anyhow = { version = "1.0.51" }

--- a/contracts/cw20-stake/src/contract.rs
+++ b/contracts/cw20-stake/src/contract.rs
@@ -28,7 +28,7 @@ pub use cw20_base::contract::{
     execute_upload_logo, query_balance, query_download_logo, query_marketing_info, query_minter,
     query_token_info,
 };
-pub use cw20_base::enumerable::{query_all_accounts, query_all_allowances};
+pub use cw20_base::enumerable::query_all_accounts;
 use cw_controllers::ClaimsResponse;
 use cw_utils::Duration;
 

--- a/contracts/cw20-staked-balance-voting/Cargo.toml
+++ b/contracts/cw20-staked-balance-voting/Cargo.toml
@@ -31,18 +31,18 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
-cw20 = "0.13"
-cw-utils = "0.13"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
+cw20 = "0.15.0"
+cw-utils = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 cw-core-macros = { version = "*", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "*", path = "../../packages/cw-core-interface" }
 cw20-stake = { path = "../cw20-stake" }
-cw20-base = { version = "0.13", features = ["library"] }
+cw20-base = { version = "0.15.0", features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"

--- a/contracts/cw20-staked-balance-voting/Cargo.toml
+++ b/contracts/cw20-staked-balance-voting/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 cw20 = "0.15.0"
@@ -44,5 +44,5 @@ cw20-stake = { path = "../cw20-stake" }
 cw20-base = { version = "0.15.0", features = ["library"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/contracts/cw4-voting/Cargo.toml
+++ b/contracts/cw4-voting/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 cw-utils = "0.15.0"
@@ -43,5 +43,5 @@ cw4 = "0.15.0"
 cw4-group = "0.15.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/contracts/cw4-voting/Cargo.toml
+++ b/contracts/cw4-voting/Cargo.toml
@@ -31,17 +31,17 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
-cw-utils = "0.13"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
+cw-utils = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 cw-core-macros = { version = "1.1.0", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "1.1.0", path = "../../packages/cw-core-interface" }
-cw4 = "0.13"
-cw4-group = "0.13"
+cw4 = "0.15.0"
+cw4-group = "0.15.0"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"

--- a/debug/cw-proposal-sudo/Cargo.toml
+++ b/debug/cw-proposal-sudo/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "1.0.0"
-cosmwasm-storage = "1.0.0"
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 schemars = "0.8"
@@ -40,5 +40,5 @@ cw-core-macros = { version = "*", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "*", path = "../../packages/cw-core-interface" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/debug/cw-proposal-sudo/Cargo.toml
+++ b/debug/cw-proposal-sudo/Cargo.toml
@@ -29,16 +29,16 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
+cosmwasm-std = "1.0.0"
+cosmwasm-storage = "1.0.0"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0" }
+thiserror = "1"
 cw-core-macros = { version = "*", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "*", path = "../../packages/cw-core-interface" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cosmwasm-schema = "1.0.0"
+cw-multi-test = "0.15.0"

--- a/debug/cw20-balance-voting/Cargo.toml
+++ b/debug/cw20-balance-voting/Cargo.toml
@@ -29,19 +29,19 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
-cw20 = "0.13"
-cw-utils = "0.13"
+cosmwasm-std = "1.0.0"
+cosmwasm-storage = "1.0.0"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
+cw20 = "0.15.0"
+cw-utils = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0" }
+thiserror = "1"
 cw-core-macros = { version = "1.1.0", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "1.1.0", path = "../../packages/cw-core-interface" }
-cw20-base = { version = "0.13", features = ["library"] }
+cw20-base = { version = "0.15.0", features = ["library"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cosmwasm-schema = "1.0.0"
+cw-multi-test = "0.15.0"

--- a/debug/cw20-balance-voting/Cargo.toml
+++ b/debug/cw20-balance-voting/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "1.0.0"
-cosmwasm-storage = "1.0.0"
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 cw20 = "0.15.0"
@@ -43,5 +43,5 @@ cw-core-interface = { version = "1.1.0", path = "../../packages/cw-core-interfac
 cw20-base = { version = "0.15.0", features = ["library"] }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/debug/proposal-hooks-counter/Cargo.toml
+++ b/debug/proposal-hooks-counter/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "1.0.0"
-cosmwasm-storage = "1.0.0"
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 cw2 = "0.15.0"
 schemars = "0.8"
@@ -50,5 +50,5 @@ cw-core = { path = "../../contracts/cw-core", version = "1.1.0", features = [
   "library",
 ] }
 cw-proposal-single = { path = "../../contracts/cw-proposal-single" }
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"

--- a/debug/proposal-hooks-counter/Cargo.toml
+++ b/debug/proposal-hooks-counter/Cargo.toml
@@ -29,26 +29,26 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
-cw2 = "0.13"
+cosmwasm-std = "1.0.0"
+cosmwasm-storage = "1.0.0"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0" }
+thiserror = "1.0"
 proposal-hooks = { version = "1.1.0", path = "../../packages/proposal-hooks" }
 vote-hooks = { version = "1.1.0", path = "../../packages/vote-hooks" }
 
 [dev-dependencies]
 indexable-hooks = { version = "1.1.0", path = "../../packages/indexable-hooks" }
-cw20 = "0.13"
+cw20 = "0.15.0"
 cw20-balance-voting = { path = "../cw20-balance-voting", version = "1.1.0" }
-cw20-base = "0.13"
-cw-utils = "0.13"
+cw20-base = "0.15.0"
+cw-utils = "0.15.0"
 voting = { version = "1.1.0", path = "../../packages/voting" }
 cw-core = { path = "../../contracts/cw-core", version = "1.1.0", features = [
   "library",
 ] }
 cw-proposal-single = { path = "../../contracts/cw-proposal-single" }
-cosmwasm-schema = { version = "1.0.0" }
-cw-multi-test = "0.13"
+cosmwasm-schema = "1.0.0"
+cw-multi-test = "0.15.0"

--- a/legacy/cw3-dao/Cargo.toml
+++ b/legacy/cw3-dao/Cargo.toml
@@ -27,11 +27,11 @@ cw20 = "0.11"
 cw20-base = { version = "0.11", features = ["library"] }
 stake-cw20 = { path = "../../contracts/cw20-stake" }
 cw-storage-plus = { version = "0.11" }
-cosmwasm-std = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
 schemars = "0.8.8"
 serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = { version = "0.11" }

--- a/legacy/cw3-multisig/Cargo.toml
+++ b/legacy/cw3-multisig/Cargo.toml
@@ -32,12 +32,12 @@ cw4 = {  version = "0.11" }
 cw20 = {  version = "0.11" }
 cw4-group = { version = "0.11" }
 cw-storage-plus = { version = "0.11" }
-cosmwasm-std = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
 schemars = "0.8.8"
 serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = {  version = "0.11" }
 cw20-base = {  version = "0.11", features = ["library"] }

--- a/legacy/cw4-registry/Cargo.toml
+++ b/legacy/cw4-registry/Cargo.toml
@@ -29,8 +29,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.11"
 cw-utils = "0.11"
 cw2 = "0.11"
@@ -43,5 +43,5 @@ thiserror = { version = "1.0.26" }
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1"
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.11"

--- a/packages/cw-core-interface/Cargo.toml
+++ b/packages/cw-core-interface/Cargo.toml
@@ -10,7 +10,7 @@ cosmwasm-std = { version = "1.0.0" }
 cw-core-macros = { version = "1.1.0", path = "../../packages/cw-core-macros" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 schemars = "0.8"
-cw2 = "0.13"
+cw2 = "0.15.0"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/packages/cw-core-interface/Cargo.toml
+++ b/packages/cw-core-interface/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
 cw-core-macros = { version = "1.1.0", path = "../../packages/cw-core-macros" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 schemars = "0.8"
 cw2 = "0.15.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"

--- a/packages/cw-core-macros/Cargo.toml
+++ b/packages/cw-core-macros/Cargo.toml
@@ -12,6 +12,6 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/packages/cw-paginate/Cargo.toml
+++ b/packages/cw-paginate/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13"
+cw-storage-plus = "0.15.0"
 serde = { version = "1.0", default-features = false }
 
 [dev-dependencies]
-cw-multi-test = "0.13"
+cw-multi-test = "0.15.0"

--- a/packages/cw-paginate/Cargo.toml
+++ b/packages/cw-paginate/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
+cosmwasm-storage = "1.1.0"
 cw-storage-plus = "0.15.0"
 serde = { version = "1.0", default-features = false }
 

--- a/packages/indexable-hooks/Cargo.toml
+++ b/packages/indexable-hooks/Cargo.toml
@@ -10,4 +10,4 @@ schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 cosmwasm-std = "1.0.0"
-cw-storage-plus = "0.13"
+cw-storage-plus = "0.15.0"

--- a/packages/indexable-hooks/Cargo.toml
+++ b/packages/indexable-hooks/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-storage-plus = "0.15.0"

--- a/packages/proposal-hooks/Cargo.toml
+++ b/packages/proposal-hooks/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 indexable-hooks = { version = "1.1.0", path = "../indexable-hooks" }

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 # targeting wasm.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rand = "0.8"
-cosmwasm-std = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
 voting = { path = "../voting", version = "*" }
 cw-multi-test = { version = "0.15.0" }

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2021"
 rand = "0.8"
 cosmwasm-std = { version = "1.0.0" }
 voting = { path = "../voting", version = "*" }
-cw-multi-test = { version = "0.13" }
+cw-multi-test = { version = "0.15.0" }

--- a/packages/vote-hooks/Cargo.toml
+++ b/packages/vote-hooks/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 indexable-hooks = { version = "1.1.0", path = "../indexable-hooks" }

--- a/packages/voting/Cargo.toml
+++ b/packages/voting/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
+cosmwasm-std = "1.1.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }


### PR DESCRIPTION
closes https://github.com/cosmorama/dao-contracts/issues/2
closes https://github.com/cosmorama/dao-contracts/issues/4

Currently blocked by lack of 0.15 release of `cw-nfts` contract https://github.com/CosmWasm/cw-nfts/tree/main/contracts/cw721-base
https://github.com/CosmWasm/cw-nfts/pull/80